### PR TITLE
Add democracy-plus-plus to other resources list

### DIFF
--- a/js/components/genOtherResourcesList.js
+++ b/js/components/genOtherResourcesList.js
@@ -28,6 +28,11 @@ const genOtherResourcesList = () => {
       url: "https://hd2random.com",
       description: "Another customizeable, ad-free loadout randomizer",
     },
+    {
+      displayName: "Democracy ++",
+      url: "https://adamlassiter.github.io/democracy-plusplus/",
+      description: "Loadout challenge runs, inspired by Budget Blitz and Special Ops",
+    },
   ];
 
   for (let i = 0; i < resources.length; i++) {


### PR DESCRIPTION
Forgive me if this a bit cheeky, but I've been a fan of helldivers2challenges.com for a while and been working on my own similar thing for a while.

Added Democracy++ to the list of resources (where you referenced hd2random.com in turn).

Understand if you don't feel it deserves a spot here yet, but I've been back developing this recently and wanted to share.