### PR TITLE
Fix Backpacks tag on Cremator.

### DIFF
--- a/js/constants/stratagems.js
+++ b/js/constants/stratagems.js
@@ -1011,7 +1011,7 @@ const STRATAGEMS = [
     displayName: "Cremator",
     type: "Stratagem",
     category: "Supply",
-    tags: ["Backpack", "Weapons"],
+    tags: ["Weapons", "Backpacks"],
     warbondCode: "warbond24",
     internalName: "cremator",
     imageURL: "cremator.svg",


### PR DESCRIPTION
The Cremator was not respecting the "always roll backpack" / "only roll one backpack" options due to a tag typo (`Backpack` instead of `Backpacks`).

Also, while I'm here, I swapped the order to match the other 8 weapons that use both the `Weapons` and `Backpacks` tags.