### PR TITLE
Add missing Weapons tag for Meltagun.

### DIFF
--- a/js/constants/stratagems.js
+++ b/js/constants/stratagems.js
@@ -1073,7 +1073,7 @@ const STRATAGEMS = [
     displayName: "Meltagun",
     type: "Stratagem",
     category: "Supply",
-    tags: ["at"],
+    tags: ["Weapons", "at"],
     warbondCode: "warbond26",
     internalName: "meltagun",
     imageURL: "meltagun.svg",


### PR DESCRIPTION
Makes it work correctly with the "only one support weapon" / "always roll support weapon" options.